### PR TITLE
Raise fatal errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Here's an example setting an error and an output:
       end
     end
 
+If you'd like the `fatal_error` to raise a `StandardError` immediately instead of bubbling up to the `Lev::Routine#errors` object, you must configure it:
+
+```ruby
+Lev.configure do |config|
+  config.raise_fatal_errors = true
+end
+```
+
 Additionally, see below for a discussion on how to transfer errors from ActiveRecord models.
 
 Any `StandardError` raised within a routine will be caught and transformed into a fatal error with `:kind` set to `:exception`.  The caller of this routine can choose to reraise this exception by calling `reraise_exception!` on the returned errors object:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Lev.configure do |config|
 end
 ```
 
+So if you `fatal_error(name: :is_blank)` it will raise `StandardError: "name is blank"`, or `fatal_error(thing: :is_broken, and: :messed_up)` it will raise `StandardError: "thing is broken - and messed up"`
+
 Additionally, see below for a discussion on how to transfer errors from ActiveRecord models.
 
 Any `StandardError` raised within a routine will be caught and transformed into a fatal error with `:kind` set to `:exception`.  The caller of this routine can choose to reraise this exception by calling `reraise_exception!` on the returned errors object:

--- a/lib/lev.rb
+++ b/lib/lev.rb
@@ -51,14 +51,14 @@ module Lev
 
     class Configuration
       # This HTML class is added to form fields that caused errors
-      attr_accessor :form_error_class
-      attr_accessor :security_transgression_error
-      attr_accessor :illegal_argument_error
+      attr_accessor :form_error_class, :security_transgression_error,
+        :illegal_argument_error, :raise_fatal_errors
 
       def initialize
         @form_error_class = 'error'
         @security_transgression_error = Lev::SecurityTransgression
         @illegal_argument_error = Lev::IllegalArgument
+        @raise_fatal_errors = false
         super
       end
     end

--- a/lib/lev.rb
+++ b/lib/lev.rb
@@ -51,8 +51,10 @@ module Lev
 
     class Configuration
       # This HTML class is added to form fields that caused errors
-      attr_accessor :form_error_class, :security_transgression_error,
-        :illegal_argument_error, :raise_fatal_errors
+      attr_accessor :form_error_class
+      attr_accessor :security_transgression_error
+      attr_accessor :illegal_argument_error
+      attr_accessor :raise_fatal_errors
 
       def initialize
         @form_error_class = 'error'

--- a/lib/lev/object.rb
+++ b/lib/lev/object.rb
@@ -10,6 +10,8 @@ class Object
 
       @active_job_queue = options[:active_job_queue]
 
+      @raise_fatal_errors = options[:raise_fatal_errors]
+
       @delegates_to = options[:delegates_to]
       if @delegates_to
         uses_routine @delegates_to,

--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -267,6 +267,11 @@ module Lev
         @nested_routines ||= {}
       end
 
+      def raise_fatal_errors?
+        @raise_fatal_errors ||
+          (Lev.configuration.raise_fatal_errors && @raise_fatal_errors.nil?)
+      end
+
       def class_to_symbol(klass)
         klass.name.underscore.gsub('/','_').to_sym
       end
@@ -397,7 +402,7 @@ module Lev
     end
 
     def fatal_error(args={})
-      if Lev.configuration.raise_fatal_errors
+      if self.class.raise_fatal_errors?
         raise StandardError, args.to_a.map { |i| i.join(' ') }.join(' - ')
       else
         errors.add(true, args)

--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -397,7 +397,7 @@ module Lev
     end
 
     def fatal_error(args={})
-      errors.add(true, args)
+      raise StandardError, args.to_a.map { |i| i.join(' ') }.join(' - ')
     end
 
     def nonfatal_error(args={})

--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -397,7 +397,11 @@ module Lev
     end
 
     def fatal_error(args={})
-      raise StandardError, args.to_a.map { |i| i.join(' ') }.join(' - ')
+      if Lev.configuration.raise_fatal_errors
+        raise StandardError, args.to_a.map { |i| i.join(' ') }.join(' - ')
+      else
+        errors.add(true, args)
+      end
     end
 
     def nonfatal_error(args={})

--- a/spec/routine_spec.rb
+++ b/spec/routine_spec.rb
@@ -40,19 +40,29 @@ describe Lev::Routine do
     }.to raise_error(NameError)
   end
 
-  it 'raises an exception on fatal_error if configured' do
-    Lev.configure do |config|
-      config.raise_fatal_errors = true
+  context 'when raise_fatal_errors is configured true' do
+    before do
+      Lev.configure do |config|
+        config.raise_fatal_errors = true
+      end
     end
 
-    expect {
-      RaiseFatalError.call
-    }.to raise_error
+    after do
+      Lev.configure do |config|
+        config.raise_fatal_errors = false
+      end
+    end
 
-    begin
-      RaiseFatalError.call
-    rescue => e
-      expect(e.message).to eq('code broken - such disaster')
+    it 'raises an exception on fatal_error if configured' do
+      expect {
+        RaiseFatalError.call
+      }.to raise_error
+
+      begin
+        RaiseFatalError.call
+      rescue => e
+        expect(e.message).to eq('code broken - such disaster')
+      end
     end
   end
 

--- a/spec/routine_spec.rb
+++ b/spec/routine_spec.rb
@@ -4,18 +4,26 @@ describe Lev::Routine do
 
   before do
     stub_const 'RaiseError', Class.new
-    RaiseError.class_eval { 
-      lev_routine 
+    RaiseError.class_eval {
+      lev_routine
       def exec
         raise 'error message'
       end
     }
 
     stub_const 'RaiseStandardError', Class.new
-    RaiseStandardError.class_eval { 
-      lev_routine 
+    RaiseStandardError.class_eval {
+      lev_routine
       def exec
         unknown_method_call
+      end
+    }
+
+    stub_const 'RaiseFatalError', Class.new
+    RaiseFatalError.class_eval {
+      lev_routine
+      def exec
+        fatal_error(code: :broken, such: :disaster)
       end
     }
   end
@@ -30,6 +38,18 @@ describe Lev::Routine do
     expect {
       RaiseStandardError.call
     }.to raise_error(NameError)
+  end
+
+  it 'raises an exception on fatal_error' do
+    expect {
+      RaiseFatalError.call
+    }.to raise_error
+
+    begin
+      RaiseFatalError.call
+    rescue => e
+      expect(e.message).to eq('code broken - such disaster')
+    end
   end
 
 end

--- a/spec/routine_spec.rb
+++ b/spec/routine_spec.rb
@@ -37,14 +37,27 @@ describe Lev::Routine do
     SpecialFatalErrorOption.class_eval {
       lev_routine raise_fatal_errors: true
       def exec
-        fatal_error(wow: :its_broken)
+        fatal_error(code: :its_broken)
       end
     }
 
+    stub_const 'NoFatalErrorOption', Class.new
+    NoFatalErrorOption.class_eval {
+      lev_routine
+      def exec
+        fatal_error(code: :no_propagate)
+      end
+    }
+
+    Lev.configure { |c| c.raise_fatal_errors = false }
+
     expect {
-      Lev.configure { |c| c.raise_fatal_errors = false }
       SpecialFatalErrorOption.call
     }.to raise_error
+
+    expect {
+      NoFatalErrorOption.call
+    }.not_to raise_error
   end
 
   it 'allows raising fatal errors config to be overridden' do
@@ -52,12 +65,13 @@ describe Lev::Routine do
     SpecialNoFatalErrorOption.class_eval {
       lev_routine raise_fatal_errors: false
       def exec
-        fatal_error(wow: :its_broken)
+        fatal_error(code: :its_broken)
       end
     }
 
+    Lev.configure { |c| c.raise_fatal_errors = true }
+
     expect {
-      Lev.configure { |c| c.raise_fatal_errors = true }
       SpecialNoFatalErrorOption.call
     }.not_to raise_error
   end

--- a/spec/routine_spec.rb
+++ b/spec/routine_spec.rb
@@ -40,7 +40,11 @@ describe Lev::Routine do
     }.to raise_error(NameError)
   end
 
-  it 'raises an exception on fatal_error' do
+  it 'raises an exception on fatal_error if configured' do
+    Lev.configure do |config|
+      config.raise_fatal_errors = true
+    end
+
     expect {
       RaiseFatalError.call
     }.to raise_error

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe 'Transactions' do
 
   context 'in nested routines' do
     it 'rolls back on exceptions' do
-      begin
+      expect {
         RollBackTransactions.call
-      rescue StandardError
-        expect(Model.count).to eq(0)
-      end
+      }.to raise_error
+
+      expect(Model.count).to eq(0)
     end
   end
 end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+unless ActiveRecord::Migration.table_exists?(:models)
+  ActiveRecord::Migration.create_table(:models)
+end
+
+class Model < ActiveRecord::Base; end
+
+RSpec.describe 'Transactions' do
+  before do
+    stub_const 'RollBackTransactions', Class.new
+    stub_const 'NestedRoutine', Class.new
+
+    NestedRoutine.class_eval do
+      lev_routine
+
+      def exec
+        raise 'Rolled back'
+      end
+    end
+
+    RollBackTransactions.class_eval do
+      lev_routine
+
+      uses_routine NestedRoutine
+
+      def exec
+        Model.create!
+        run(:nested_routine)
+      end
+    end
+  end
+
+  context 'in nested routines' do
+    it 'rolls back on exceptions' do
+      begin
+        RollBackTransactions.call
+      rescue StandardError
+        expect(Model.count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1156756/stories/93674254

Adds:
* `raise_fatal_errors` configuration (default: false)
* `fatal_error` will raise a `StandardError` immediately if the above setting is configured to `true`
* README update about this