### PR TITLE
Conditional error exception raising at RoutineCalledLikeThis[]

### DIFF
--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -202,7 +202,7 @@ module Lev
 
       def [](*args, &block)
         result = call(*args, &block)
-        result.errors.raise_exception_if_any!
+        result.errors.raise_exception_if_any! if raise_fatal_errors?
         result.outputs.send(@express_output)
       end
 

--- a/spec/routine_spec.rb
+++ b/spec/routine_spec.rb
@@ -79,6 +79,7 @@ describe Lev::Routine do
 
     expect {
       SpecialNoFatalErrorOption.call
+      SpecialNoFatalErrorOption[]
     }.not_to raise_error
   end
 


### PR DESCRIPTION
4.2.1 please, fixes a bug when routines are `Called[like: this]`