### PR TITLE
Background job routine status

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ The store needs to respond to the following methods:
 1. fetch(key)
 2. write(key, value)
 
-The default store is essentially a hash (implemented in `Lev::SimpleMemoryStatusStore`).  Any `ActiveSupport::Cache::Store` will work.
+The default store is essentially a hash (implemented in `Lev::MemoryStore`).  Any `ActiveSupport::Cache::Store` will work.
 
 A routine's status can be retrieved with `Lev::Status.get(uuid_here)`.  This just returns a simple hash.  Notable keys are
 

--- a/lib/lev.rb
+++ b/lib/lev.rb
@@ -56,6 +56,7 @@ module Lev
       attr_accessor :illegal_argument_error
       attr_accessor :raise_fatal_errors
       attr_accessor :active_job_class
+      attr_accessor :status_store
 
       def initialize
         @form_error_class = 'error'
@@ -63,6 +64,7 @@ module Lev
         @illegal_argument_error = Lev::IllegalArgument
         @raise_fatal_errors = false
         @active_job_class = defined?(ActiveJob) ? ActiveJob::Base : nil
+        @status_store = Lev::SimpleMemoryStatusStore.new
         super
       end
     end

--- a/lib/lev.rb
+++ b/lib/lev.rb
@@ -24,6 +24,10 @@ require "lev/form_builder"
 require "lev/delegate_to_routine"
 require "lev/transaction_isolation"
 
+require 'lev/memory_store'
+
+require 'lev/status'
+require 'lev/black_hole_status'
 
 module Lev
   class << self
@@ -65,7 +69,7 @@ module Lev
         @illegal_argument_error = Lev::IllegalArgument
         @raise_fatal_errors = false
         @active_job_class = defined?(ActiveJob) ? ActiveJob::Base : nil
-        @status_store = Lev::SimpleMemoryStatusStore.new
+        @status_store = Lev::MemoryStore.new
         @status_store_namespace = "lev_status"
         super
       end

--- a/lib/lev.rb
+++ b/lib/lev.rb
@@ -57,6 +57,7 @@ module Lev
       attr_accessor :raise_fatal_errors
       attr_accessor :active_job_class
       attr_accessor :status_store
+      attr_accessor :status_store_namespace
 
       def initialize
         @form_error_class = 'error'
@@ -65,6 +66,7 @@ module Lev
         @raise_fatal_errors = false
         @active_job_class = defined?(ActiveJob) ? ActiveJob::Base : nil
         @status_store = Lev::SimpleMemoryStatusStore.new
+        @status_store_namespace = "lev_status"
         super
       end
     end

--- a/lib/lev/black_hole_status.rb
+++ b/lib/lev/black_hole_status.rb
@@ -1,0 +1,22 @@
+module Lev
+  class BlackHoleStatus
+
+    # Provide null object pattern methods for status setters; routines should
+    # not be checking their own status (they should know it), and outside callers
+    # should not be checking status unless the status object is a real one.
+
+    def set_progress(*); end
+    def save(*); end
+    def add_error(*); end
+
+    def self.method_missing(method_sym, *args, &block)
+      if Lev::Status.new.respond_to?(method_sym)
+        raise NameError,
+              "'#{method_sym}' is Status query method, and those cannot be called on BlackHoleStatus"
+      else
+        super
+      end
+    end
+
+  end
+end

--- a/lib/lev/black_hole_status.rb
+++ b/lib/lev/black_hole_status.rb
@@ -9,8 +9,8 @@ module Lev
     def save(*); end
     def add_error(*); end
 
-    Lev::Status::STATUSES.each do |status|
-      define_method("#{status}!") do; end
+    Lev::Status::STATES.each do |state|
+      define_method("#{state}!") do; end
     end
 
     def self.method_missing(method_sym, *args, &block)

--- a/lib/lev/black_hole_status.rb
+++ b/lib/lev/black_hole_status.rb
@@ -9,10 +9,14 @@ module Lev
     def save(*); end
     def add_error(*); end
 
+    Lev::Status.STATUSES.each do |status|
+      define_method("#{status}!") do; end
+    end
+
     def self.method_missing(method_sym, *args, &block)
       if Lev::Status.new.respond_to?(method_sym)
         raise NameError,
-              "'#{method_sym}' is Status query method, and those cannot be called on BlackHoleStatus"
+              "'#{method_sym}' is Lev::Status query method, and those cannot be called on BlackHoleStatus"
       else
         super
       end

--- a/lib/lev/black_hole_status.rb
+++ b/lib/lev/black_hole_status.rb
@@ -9,7 +9,7 @@ module Lev
     def save(*); end
     def add_error(*); end
 
-    Lev::Status.STATUSES.each do |status|
+    Lev::Status::STATUSES.each do |status|
       define_method("#{status}!") do; end
     end
 

--- a/lib/lev/errors.rb
+++ b/lib/lev/errors.rb
@@ -4,12 +4,29 @@ module Lev
   #
   class Errors < Array
 
+    def initialize(routine_status = nil, raise_fatal_errors = false)
+      @routine_status = routine_status || DummyStatus.new
+      @raise_fatal_errors = raise_fatal_errors
+    end
+
     def add(fail, args={})
       args[:kind] ||= :lev
       error = Error.new(args)
+
       return if ignored_error_procs.any?{|proc| proc.call(error)}
       self.push(error)
-      throw :fatal_errors_encountered if fail
+
+      routine_status.add_error(fail, error)
+
+      if fail
+        routine_status.failed!
+
+        if raise_fatal_errors
+          raise StandardError, args.to_a.map { |i| i.join(' ') }.join(' - ')
+        else
+          throw :fatal_errors_encountered
+        end
+      end
     end
 
     def ignore(arg)
@@ -35,7 +52,17 @@ module Lev
       raise exception_type, collect{|error| error.message}.join('; ') if any?
     end
 
+
+
   protected
+
+    class DummyStatus
+      def save(*); end
+      def failed!(*); end
+    end
+
+    attr_reader :routine_status
+    attr_reader :raise_fatal_errors
 
     def ignored_error_procs
       @ignored_error_procs ||= []

--- a/lib/lev/errors.rb
+++ b/lib/lev/errors.rb
@@ -16,7 +16,7 @@ module Lev
       return if ignored_error_procs.any?{|proc| proc.call(error)}
       self.push(error)
 
-      routine_status.add_error(fail, error)
+      routine_status.add_error(error, is_fatal: fail)
 
       if fail
         routine_status.failed!

--- a/lib/lev/errors.rb
+++ b/lib/lev/errors.rb
@@ -5,7 +5,7 @@ module Lev
   class Errors < Array
 
     def initialize(routine_status = nil, raise_fatal_errors = false)
-      @routine_status = routine_status || DummyStatus.new
+      @routine_status = routine_status || BlackHoleStatus.new
       @raise_fatal_errors = raise_fatal_errors
     end
 
@@ -52,14 +52,7 @@ module Lev
       raise exception_type, collect{|error| error.message}.join('; ') if any?
     end
 
-
-
   protected
-
-    class DummyStatus
-      def save(*); end
-      def failed!(*); end
-    end
 
     attr_reader :routine_status
     attr_reader :raise_fatal_errors

--- a/lib/lev/memory_store.rb
+++ b/lib/lev/memory_store.rb
@@ -1,5 +1,5 @@
 module Lev
-  class SimpleMemoryStatusStore
+  class MemoryStore
 
     def initialize
       @store = {}

--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -242,7 +242,7 @@ module Lev
 
           active_job_class.perform_later(*args, &block)
 
-          status.uuid()
+          status.uuid
         end
 
         def active_job_queue

--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -238,7 +238,7 @@ module Lev
 
           status = Lev::Status.new
           status.queued!
-          args.push(status.uuid
+          args.push(status.uuid)
 
           active_job_class.perform_later(*args, &block)
 
@@ -447,7 +447,7 @@ module Lev
       @after_transaction_blocks.push(block)
     end
 
-    def initialize(status=nil)
+    def initialize(status = nil)
       # If someone cares about the status, they'll pass it in; otherwise all
       # status updates go into the bit bucket.
       @status = status || Lev::BlackHoleStatus.new

--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -316,7 +316,7 @@ module Lev
         block.call
       end
 
-      status.completed!
+      status.completed! if !errors?
 
       result
     end

--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -221,9 +221,9 @@ module Lev
               end
 
               def perform(*args, &block)
-                # perform_later made a status object be the last argument
-                status = args.pop
-                routine_instance = routine_class.new(status)
+                # perform_later made a status uuid be the last argument
+                uuid = args.pop
+                routine_instance = routine_class.new(Lev::Status.new(uuid))
                 routine_instance.call(*args, &block)
               end
             end
@@ -238,7 +238,7 @@ module Lev
 
           status = Lev::Status.new
           status.queued!
-          args.push(status)
+          args.push(status.uuid
 
           active_job_class.perform_later(*args, &block)
 

--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -450,7 +450,7 @@ module Lev
     def initialize(status=nil)
       # If someone cares about the status, they'll pass it in; otherwise all
       # status updates go into the bit bucket.
-      @status = status || BlackHoleStatus.new
+      @status = status || Lev::BlackHoleStatus.new
     end
 
   protected

--- a/lib/lev/simple_memory_status_store.rb
+++ b/lib/lev/simple_memory_status_store.rb
@@ -1,0 +1,17 @@
+module Lev
+  class SimpleMemoryStatusStore
+
+    def initialize
+      @store = {}
+    end
+
+    def fetch(key)
+      @store[key]
+    end
+
+    def write(key, value)
+      @store[key] = value
+    end
+
+  end
+end

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -32,11 +32,12 @@ module Lev
     end
 
     def set_progress(at, out_of = nil)
-      prevent_faulty_arguments(at, out_of)
+      progress = compute_fractional_progress(at, out_of)
 
-      if set_status_progress(at, out_of) == 1.0
-        set(state: STATE_COMPLETED)
-      end
+      data_to_set = { progress: progress }
+      data_to_set[:state] = STATE_COMPLETED if 1.0 == progress
+
+      set(data_to_set)
     end
 
     STATES.each do |state|
@@ -105,25 +106,18 @@ module Lev
       end
     end
 
-    def set_status_progress(at, out_of)
-      if out_of.nil? && (at < 0 || at > 1)
-        raise IllegalArgument,
-              "If `out_of` not specified, `at` must be in the range [0.0, 1.0]"
-      elsif out_of.nil?
-        set(progress: at)
-      else
-        set(progress: (at.to_f / out_of.to_f))
-      end
-    end
-
-    def prevent_faulty_arguments(at, out_of)
+    def compute_fractional_progress(at, out_of)
       if at.nil?
         raise IllegalArgument, "Must specify at least `at` argument to `progress` call"
       elsif at < 0
         raise IllegalArgument, "progress cannot be negative (at=#{at})"
       elsif out_of && out_of < at
         raise IllegalArgument, "`out_of` must be greater than `at` in `progress` calls"
+      elsif out_of.nil? && (at < 0 || at > 1)
+        raise IllegalArgument, "If `out_of` not specified, `at` must be in the range [0.0, 1.0]"
       end
+
+      at.to_f / (out_of || 1).to_f
     end
 
   end

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -23,7 +23,11 @@ module Lev
     end
 
     def self.find(uuid)
-      store.fetch(status_key(uuid))
+      if status = store.fetch(status_key(uuid))
+        decode(status)
+      else
+        nil
+      end
     end
 
     def set_progress(at, out_of = nil)
@@ -58,7 +62,7 @@ module Lev
 
     def get(key)
       if value = self.class.store.fetch(status_key)
-        decoded_hash = JSON.parse(value)
+        decoded_hash = decode(value)
         decoded_hash.merge(uuid: uuid)[key]
       else
         false
@@ -120,6 +124,14 @@ module Lev
       elsif out_of && out_of < at
         raise IllegalArgument, "`out_of` must be greater than `at` in `progress` calls"
       end
+    end
+
+    def self.decode(value)
+      JSON.parse(value)
+    end
+
+    def decode(value)
+      self.class.decode(value)
     end
 
   end

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -23,11 +23,11 @@ module Lev
 
     attr_reader :uuid
 
-    def initialize(uuid)
-      @uuid = uuid
+    def initialize
+      @uuid = SecureRandom.uuid()
     end
 
-    def progress(at, out_of = nil)
+    def set_progress(at, out_of = nil)
       raise IllegalArgument, "Must specify at least `at` argument to `progress` call" if at.nil?
       raise IllegalArgument, "progress cannot be negative (at=#{at})" if at < 0
       raise IllegalArgument, "`out_of` must be greater than `at` in `progress` calls" unless out_of > at
@@ -85,6 +85,8 @@ module Lev
     RESERVED_KEYS = [:progress, :uuid, :status, :errors]
 
     def self.store
+      # Nice to get the store from lev config each time so it isn't serialized
+      # when activejobs are sent off to places like redis
       Lev.configuration.status_store
     end
 

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -2,18 +2,18 @@ require 'json'
 
 module Lev
   class Status
-    STATUS_QUEUED = 'queued'
-    STATUS_WORKING = 'working'
-    STATUS_COMPLETED = 'completed'
-    STATUS_FAILED = 'failed'
-    STATUS_KILLED = 'killed'
+    STATE_QUEUED = 'queued'
+    STATE_WORKING = 'working'
+    STATE_COMPLETED = 'completed'
+    STATE_FAILED = 'failed'
+    STATE_KILLED = 'killed'
 
-    STATUSES = [
-      STATUS_QUEUED,
-      STATUS_WORKING,
-      STATUS_COMPLETED,
-      STATUS_FAILED,
-      STATUS_KILLED
+    STATES = [
+      STATE_QUEUED,
+      STATE_WORKING,
+      STATE_COMPLETED,
+      STATE_FAILED,
+      STATE_KILLED
     ].freeze
 
     attr_reader :uuid
@@ -35,13 +35,13 @@ module Lev
       prevent_faulty_arguments(at, out_of)
 
       if set_status_progress(at, out_of) == 1.0
-        set(status: STATUS_COMPLETED)
+        set(state: STATE_COMPLETED)
       end
     end
 
-    STATUSES.each do |status|
-      define_method("#{status}!") do
-        set(status: status)
+    STATES.each do |state|
+      define_method("#{state}!") do
+        set(state: state)
       end
     end
 
@@ -66,7 +66,7 @@ module Lev
     end
 
     protected
-    RESERVED_KEYS = [:progress, :uuid, :status, :errors]
+    RESERVED_KEYS = [:progress, :uuid, :state, :errors]
 
     def self.store
       # Nice to get the store from lev config each time so it isn't serialized
@@ -83,7 +83,7 @@ module Lev
     end
 
     def status_key
-      "#{Lev.configuration.status_store_namespace}:#{uuid}"
+      self.class.status_key(uuid)
     end
 
     def self.status_key(uuid)
@@ -99,9 +99,9 @@ module Lev
       set(key => new_value)
     end
 
-    STATUSES.each do |status|
-      define_method("#{status}?") do
-        get('status') == status
+    STATES.each do |state|
+      define_method("#{state}?") do
+        get('state') == state
       end
     end
 

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -97,7 +97,7 @@ module Lev
     end
 
     def status_key(uuid)
-      "status:#{uuid}" # TODO make this namespace configurable
+      "#{Lev.configuration.status_store_namespace}:#{uuid}"
     end
 
     def has_reserved_keys?(hash)

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -47,15 +47,7 @@ module Lev
       set(data_to_set)
     end
 
-    def progress
-      get('progress')
-    end
-
     STATUSES.each do |status|
-      define_method("#{status}?") do
-        get('status') === status
-      end
-
       define_method("#{status}!") do
         set('status', status)
       end
@@ -74,10 +66,6 @@ module Lev
         code: error.code,
         message: error.message
       })
-    end
-
-    def errors
-      get('errors') || []
     end
 
     protected
@@ -119,6 +107,12 @@ module Lev
     def push(key, new_item)
       new_value = (get(key) || []).push(new_item)
       set(key: new_value)
+    end
+
+    STATUSES.each do |status|
+      define_method("#{status}?") do
+        get('status') === status
+      end
     end
 
   end

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -2,7 +2,6 @@ require 'json'
 
 module Lev
   class Status
-
     STATUS_QUEUED = 'queued'
     STATUS_WORKING = 'working'
     STATUS_COMPLETED = 'completed'

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -18,8 +18,8 @@ module Lev
 
     attr_reader :uuid
 
-    def initialize
-      @uuid = SecureRandom.uuid()
+    def initialize(uuid=nil)
+      @uuid = uuid || SecureRandom.uuid()
     end
 
     def set_progress(at, out_of = nil)

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -20,11 +20,12 @@ module Lev
 
     def initialize(uuid = nil)
       @uuid = uuid || SecureRandom.uuid
+      save
     end
 
     def self.find(uuid)
       if status = store.fetch(status_key(uuid))
-        decode(status)
+        JSON.parse(status)
       else
         nil
       end
@@ -44,7 +45,7 @@ module Lev
       end
     end
 
-    def save(hash)
+    def save(hash = {})
       if has_reserved_keys?(hash)
         raise IllegalArgument,
               "Caller cannot specify any reserved keys (#{RESERVED_KEYS})"
@@ -61,12 +62,7 @@ module Lev
     end
 
     def get(key)
-      if value = self.class.store.fetch(status_key)
-        decoded_hash = decode(value)
-        decoded_hash.merge(uuid: uuid)[key]
-      else
-        false
-      end
+      self.class.find(uuid)[key]
     end
 
     protected
@@ -128,14 +124,6 @@ module Lev
       elsif out_of && out_of < at
         raise IllegalArgument, "`out_of` must be greater than `at` in `progress` calls"
       end
-    end
-
-    def self.decode(value)
-      JSON.parse(value)
-    end
-
-    def decode(value)
-      self.class.decode(value)
     end
 
   end

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -79,6 +79,10 @@ module Lev
     end
 
     def set(incoming_hash)
+      if existing_settings = self.class.find(uuid)
+        incoming_hash = existing_settings.merge(incoming_hash)
+      end
+
       self.class.store.write(status_key, incoming_hash.to_json)
     end
 

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -18,18 +18,20 @@ module Lev
 
     attr_reader :uuid
 
-    def initialize(uuid=nil)
-      @uuid = uuid || SecureRandom.uuid()
+    def initialize(uuid = nil)
+      @uuid = uuid || SecureRandom.uuid
+    end
+
+    def self.find(uuid)
+      store.fetch(status_key(uuid))
     end
 
     def set_progress(at, out_of = nil)
       prevent_faulty_arguments(at, out_of)
 
-      progress = set_status_progress(at, out_of)
-      data_to_set = { progress: progress }
-      data_to_set[:status] = STATUS_COMPLETED if progress == 1.0
-
-      set(data_to_set)
+      if set_status_progress(at, out_of) == 1.0
+        set(status: STATUS_COMPLETED)
+      end
     end
 
     STATUSES.each do |status|
@@ -77,6 +79,10 @@ module Lev
     end
 
     def status_key
+      "#{Lev.configuration.status_store_namespace}:#{uuid}"
+    end
+
+    def self.status_key(uuid)
       "#{Lev.configuration.status_store_namespace}:#{uuid}"
     end
 

--- a/lib/lev/status.rb
+++ b/lib/lev/status.rb
@@ -1,0 +1,124 @@
+require 'json'
+
+module Lev
+  class Status
+
+    STATUS_QUEUED = 'queued'
+    STATUS_WORKING = 'working'
+    STATUS_COMPLETED = 'completed'
+    STATUS_FAILED = 'failed'
+    STATUS_KILLED = 'killed'
+    STATUSES = [
+      STATUS_QUEUED,
+      STATUS_WORKING,
+      STATUS_COMPLETED,
+      STATUS_FAILED,
+      STATUS_KILLED
+    ].freeze
+
+    def self.get(uuid)
+      decoded_hash = decode(self.store.fetch(status_key(uuid)))
+      decoded_hash.merge(uuid: uuid)
+    end
+
+    attr_reader :uuid
+
+    def initialize(uuid)
+      @uuid = uuid
+    end
+
+    def progress(at, out_of = nil)
+      raise IllegalArgument, "Must specify at least `at` argument to `progress` call" if at.nil?
+      raise IllegalArgument, "progress cannot be negative (at=#{at})" if at < 0
+      raise IllegalArgument, "`out_of` must be greater than `at` in `progress` calls" unless out_of > at
+
+      progress =
+        if out_of.nil?
+          raise IllegalArgument, "If `out_of` not specified, `at` must be in the range [0.0,1.0]" \
+            if at < 0 || at > 1
+          set(progress: at)
+        else
+          set(progress: (at.to_f / out_of.to_f))
+        end
+
+      data_to_set = { progress: progress }
+      data_to_set[:status] = STATUS_COMPLETED if progress == 1.0
+
+      set(data_to_set)
+    end
+
+    def progress
+      get('progress')
+    end
+
+    STATUSES.each do |status|
+      define_method("#{status}?") do
+        get('status') === status
+      end
+
+      define_method("#{status}!") do
+        set('status', status)
+      end
+    end
+
+    def save(hash)
+      raise IllegalArgument, "Caller cannot specify any reserved keys (#{RESERVED_KEYS})" \
+        if has_reserved_keys?(hash)
+
+      set(hash)
+    end
+
+    def add_error(is_fatal, error)
+      push('errors', {
+        is_fatal: is_fatal,
+        code: error.code,
+        message: error.message
+      })
+    end
+
+    def errors
+      get('errors') || []
+    end
+
+    protected
+
+    RESERVED_KEYS = [:progress, :uuid, :status, :errors]
+
+    def self.store
+      Lev.configuration.status_store
+    end
+
+    def set(incoming_hash)
+      decoded_hash = self.get(uuid)
+      decoded_hash.merge(incoming_hash)
+      self.store.write(status_key(uuid), encode(decoded_hash))
+    end
+
+    def get(key)
+      self.get(uuid)[key]
+    end
+
+    def encode(val)
+      val.to_json
+    end
+
+    def decode(val)
+      JSON.parse(val)
+    end
+
+    def status_key(uuid)
+      "status:#{uuid}" # TODO make this namespace configurable
+    end
+
+    def has_reserved_keys?(hash)
+      (hash.keys.collect{|key| key.to_sym} & RESERVED_KEYS).any?
+    end
+
+    def push(key, new_item)
+      new_value = (get(key) || []).push(new_item)
+      set(key: new_value)
+    end
+
+  end
+end
+

--- a/spec/active_job_routines_spec.rb
+++ b/spec/active_job_routines_spec.rb
@@ -1,8 +1,4 @@
-require 'active_job'
 require 'spec_helper'
-
-ActiveJob::Base.queue_adapter = :test
-ActiveJob::Base.logger = ::Logger.new(nil)
 
 RSpec.describe 'ActiveJob routines' do
   context 'default configuration' do

--- a/spec/active_job_routines_spec.rb
+++ b/spec/active_job_routines_spec.rb
@@ -27,12 +27,11 @@ RSpec.describe 'ActiveJob routines' do
   end
 
   context 'specialized configuration' do
-    before do
-      Lev.configure { |c| c.active_job_class = SomeOtherJobBase }
-    end
+    before { Lev.configure { |c| c.active_job_class = SomeOtherJobBase } }
+    after { Lev.configure { |c| c.active_job_class = ActiveJob::Base } }
 
     class SomeOtherJobBase
-      def self.queue_as(*args); end
+      def self.queue_as(*); end
       def self.perform_later; end
     end
 

--- a/spec/routine_spec.rb
+++ b/spec/routine_spec.rb
@@ -111,7 +111,7 @@ describe Lev::Routine do
       begin
         RaiseFatalError.call
       rescue => e
-        expect(e.message).to eq('code broken - such disaster')
+        expect(e.message).to eq('code broken - such disaster - kind lev')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,12 @@
 # loaded once.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'active_job'
+
+ActiveJob::Base.queue_adapter = :test
+ActiveJob::Base.logger = ::Logger.new(nil)
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus

--- a/spec/statused_routines_spec.rb
+++ b/spec/statused_routines_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+RSpec.describe 'Statused Routines' do
+  subject(:status) { Lev::Status.new }
+
+  describe '#save' do
+    it 'prevents the use of reserved keys' do
+      expect {
+        status.save(progress: 'blocked')
+      }.to raise_error(Lev::IllegalArgument)
+
+      expect {
+        status.save(uuid: 'blocked')
+      }.to raise_error(Lev::IllegalArgument)
+
+      expect {
+        status.save(status: 'blocked')
+      }.to raise_error(Lev::IllegalArgument)
+
+      expect {
+        status.save(errors: 'blocked')
+      }.to raise_error(Lev::IllegalArgument)
+    end
+
+    it 'saves the hash given and writes them to the status' do
+      status.save(something: 'else')
+      expect(status.get('something')).to eq('else')
+    end
+  end
+
+  describe '#add_error' do
+    it 'adds the error object data to the status object' do
+      errors = Lev::Error.new(code: 'bad', message: 'awful')
+      status.add_error(errors)
+      expect(status.get('errors')).to eq([{ 'is_fatal' => false,
+                                            'code' => 'bad',
+                                            'message' => 'awful' }])
+    end
+  end
+
+  describe 'dynamic status setters/getters' do
+    it 'is queued' do
+      expect(status).not_to be_queued
+      status.queued!
+      expect(status).to be_queued
+    end
+
+    it 'is working' do
+      expect(status).not_to be_working
+      status.working!
+      expect(status).to be_working
+    end
+
+    it 'is completed' do
+      expect(status).not_to be_completed
+      status.completed!
+      expect(status).to be_completed
+    end
+
+    it 'is failed' do
+      expect(status).not_to be_failed
+      status.failed!
+      expect(status).to be_failed
+    end
+
+    it 'is killed' do
+      expect(status).not_to be_killed
+      status.killed!
+      expect(status).to be_killed
+    end
+  end
+
+  describe '#set_progress' do
+    it 'requires a positive `at` integer value' do
+
+      expect {
+        status.set_progress(nil)
+      }.to raise_error(Lev::IllegalArgument)
+
+      expect {
+        status.set_progress(-1)
+      }.to raise_error(Lev::IllegalArgument)
+
+      expect {
+        status.set_progress(1)
+      }.not_to raise_error
+    end
+
+    it 'requires `out_of` to be greater than `at` if set' do
+      expect {
+        status.set_progress(15, 8)
+      }.to raise_error(Lev::IllegalArgument)
+
+      expect {
+        status.set_progress(5, 10)
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/statused_routines_spec.rb
+++ b/spec/statused_routines_spec.rb
@@ -1,8 +1,4 @@
-require 'active_job'
 require 'spec_helper'
-
-ActiveJob::Base.queue_adapter = :inline
-ActiveJob::Base.logger = ::Logger.new(nil)
 
 class StatusedRoutine
   lev_routine

--- a/spec/statused_routines_spec.rb
+++ b/spec/statused_routines_spec.rb
@@ -1,7 +1,27 @@
+require 'active_job'
 require 'spec_helper'
+
+ActiveJob::Base.queue_adapter = :test
+ActiveJob::Base.logger = ::Logger.new(nil)
 
 RSpec.describe 'Statused Routines' do
   subject(:status) { Lev::Status.new }
+
+  context 'in a routine' do
+    it 'works so wonderfully' do
+      stub_const 'StatusedRoutine', Class.new
+      StatusedRoutine.class_eval do
+        lev_routine
+        protected
+        def exec
+          set_progress(9, 10)
+        end
+      end
+
+      outputs = StatusedRoutine.perform_later.outputs
+      expect(outputs.status[:progress]).to eq(0.9)
+    end
+  end
 
   describe '#save' do
     it 'prevents the use of reserved keys' do

--- a/spec/statused_routines_spec.rb
+++ b/spec/statused_routines_spec.rb
@@ -71,29 +71,47 @@ RSpec.describe 'Statused Routines' do
   end
 
   describe '#set_progress' do
-    it 'requires a positive `at` integer value' do
+    context 'when `out_of` is supplied' do
+      it 'requires a positive `at` float or integer' do
+        expect {
+          status.set_progress(nil, 1)
+        }.to raise_error(Lev::IllegalArgument)
 
-      expect {
-        status.set_progress(nil)
-      }.to raise_error(Lev::IllegalArgument)
+        expect {
+          status.set_progress(-1, 1)
+        }.to raise_error(Lev::IllegalArgument)
 
-      expect {
-        status.set_progress(-1)
-      }.to raise_error(Lev::IllegalArgument)
+        expect {
+          status.set_progress(2, 5)
+        }.not_to raise_error
+      end
 
-      expect {
-        status.set_progress(1)
-      }.not_to raise_error
+      it 'requires `out_of` to be greater than `at`' do
+        expect {
+          status.set_progress(15, 8)
+        }.to raise_error(Lev::IllegalArgument)
+
+        expect {
+          status.set_progress(5, 10)
+        }.not_to raise_error
+      end
     end
 
-    it 'requires `out_of` to be greater than `at` if set' do
-      expect {
-        status.set_progress(15, 8)
-      }.to raise_error(Lev::IllegalArgument)
+    context 'without out_of specified' do
+      it 'requires `at` to be a float between 0.0 and 1.0' do
+        expect {
+          status.set_progress(1.1)
+        }.to raise_error(Lev::IllegalArgument)
 
-      expect {
-        status.set_progress(5, 10)
-      }.not_to raise_error
+        expect {
+          status.set_progress(-1)
+        }.to raise_error(Lev::IllegalArgument)
+
+        expect {
+          status.set_progress(0.78)
+        }.not_to raise_error
+      end
     end
+
   end
 end

--- a/spec/statused_routines_spec.rb
+++ b/spec/statused_routines_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Statused Routines' do
         lev_routine
         protected
         def exec
-          set_progress(9, 10)
+          outputs.status.set_progress(9, 10)
         end
       end
 

--- a/spec/statused_routines_spec.rb
+++ b/spec/statused_routines_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Statused Routines' do
       uuid = StatusedRoutine.perform_later
       status = Lev::Status.find(uuid)
 
-      expect(status['status']).to eq(Lev::Status::STATUS_QUEUED)
+      expect(status['state']).to eq(Lev::Status::STATE_QUEUED)
     end
 
     context 'inline activejob mode' do
@@ -32,7 +32,7 @@ RSpec.describe 'Statused Routines' do
       it 'completes the status object on completion, returning other data' do
         uuid = StatusedRoutine.perform_later
         status = Lev::Status.find(uuid)
-        expect(status['status']).to eq(Lev::Status::STATUS_COMPLETED)
+        expect(status['state']).to eq(Lev::Status::STATE_COMPLETED)
         expect(status['progress']).to eq(0.9)
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe 'Statused Routines' do
       }.to raise_error(Lev::IllegalArgument)
 
       expect {
-        status.save(status: 'blocked')
+        status.save(state: 'blocked')
       }.to raise_error(Lev::IllegalArgument)
 
       expect {


### PR DESCRIPTION
This PR adds infrastructure to support reporting of routine status when run as a background job.  Instead of relying on one of the existing `<background job system>-status` gems out there, this PR implements a simple status mechanism that is `ActiveJob` friendly and ties into the existing Lev infrastructure. 

Tests not included :-)