### PR TITLE
Added Lev::RedisStore

### DIFF
--- a/lib/lev.rb
+++ b/lib/lev.rb
@@ -26,6 +26,7 @@ require "lev/transaction_isolation"
 
 require 'lev/active_job'
 require 'lev/memory_store'
+require 'lev/redis_store'
 require 'lev/status'
 require 'lev/black_hole_status'
 

--- a/lib/lev/redis_store.rb
+++ b/lib/lev/redis_store.rb
@@ -1,0 +1,17 @@
+module Lev
+  class RedisStore
+
+    def initialize(*args)
+      @redis_store = Redis::Store.new(*args)
+    end
+
+    def fetch(key)
+      @redis_store.get(key)
+    end
+
+    def write(key, value)
+      @redis_store.set(key, value)
+    end
+
+  end
+end


### PR DESCRIPTION
We could also, instead, just change the `Lev::MemoryStore` to have the same API as the `::Redis::Store` and use that directly.