### PR TITLE
Modify Lev::BackgroundJob to not write to store for .find

### DIFF
--- a/lib/lev/background_job.rb
+++ b/lib/lev/background_job.rb
@@ -20,8 +20,10 @@ module Lev
       STATE_UNKNOWN
     ].freeze
 
-    def initialize(attrs = {})
+    def initialize(attrs = {}, opts = {})
       attrs.stringify_keys!
+      opts[:write] = true if opts[:write].nil?
+
       @id = attrs['id'] || SecureRandom.uuid
       @status = attrs['status'] || STATE_UNKNOWN
       @progress = attrs['progress'] || 0
@@ -30,7 +32,7 @@ module Lev
       set({ id: id,
             status: status,
             progress: progress,
-            errors: errors })
+            errors: errors }) if opts[:write]
     end
 
     def self.find(id)
@@ -42,7 +44,7 @@ module Lev
         attrs.merge!(status: STATE_UNKNOWN)
       end
 
-      new(attrs)
+      new(attrs, { write: false })
     end
 
     def self.all

--- a/spec/background_job_spec.rb
+++ b/spec/background_job_spec.rb
@@ -79,4 +79,14 @@ describe Lev::BackgroundJob do
     expect(job.progress).to eq 1
   end
 
+  describe '.find' do
+    let!(:job) { described_class.new }
+
+    it 'does not write to store' do
+      expect(described_class.store).to_not receive(:write)
+      found_job = described_class.find(job.id)
+      expect(found_job.as_json).to eq(job.as_json)
+    end
+  end
+
 end


### PR DESCRIPTION
`Lev::BackgroundJob.find` was writing to store which causes
`Lev::BackgroundJob.all` to be very slow.  `.find` needs to create a new
instance of `Lev::BackgroundJob` but does not need to write to store.

The performance improvement on tutor-server for 1174 background jobs is
more than 10 times.  Doing `Lev::BackgroundJob.all` took 1.58s, now it
only takes 0.14s.