### PR TITLE
Made handlers that use params not blow up when transactions are retried

### DIFF
--- a/lib/lev/handler.rb
+++ b/lib/lev/handler.rb
@@ -14,28 +14,28 @@ module Lev
     end
   end
 
-  # Common methods for all handlers.  Handlers are extensions of Routines 
-  # and are responsible for taking input data from a form or other widget and 
+  # Common methods for all handlers.  Handlers are extensions of Routines
+  # and are responsible for taking input data from a form or other widget and
   # doing something with it.  See Lev::Routine for more information.
   #
   # All handlers must:
   #   2) call "lev_handler"
-  #   3) implement the 'handle' method which takes no arguments and does the 
+  #   3) implement the 'handle' method which takes no arguments and does the
   #      work the handler is charged with
-  #   4) implement the 'authorized?' method which returns true iff the 
+  #   4) implement the 'authorized?' method which returns true iff the
   #      caller is authorized to do what the handler is charged with
   #
   # Handlers may:
   #   1) implement the 'setup' method which runs before 'authorized?' and 'handle'.
-  #      This method can do anything, and will likely include setting up some 
+  #      This method can do anything, and will likely include setting up some
   #      instance objects based on the params.
   #   2) Call the class method "paramify" to declare, cast, and validate parts of
   #      the params hash. The first argument to paramify is the key in params
   #      which points to a hash of params to be paramified.  If this first argument
-  #      is unspecified (or specified as `:paramify`, a reserved symbol), the entire 
-  #      params hash will be paramified.  The block passed to paramify looks just 
+  #      is unspecified (or specified as `:paramify`, a reserved symbol), the entire
+  #      params hash will be paramified.  The block passed to paramify looks just
   #      like the guts of an ActiveAttr model.
-  #      
+  #
   #      When the incoming params includes :search => {:type, :terms, :num_results}
   #      the Handler class would look like:
   #
@@ -53,9 +53,9 @@ module Lev
   #
   #          attribute :num_results, type: Integer
   #          validates :num_results, numericality: { only_integer: true,
-  #                                            greater_than_or_equal_to: 0 }                               
+  #                                            greater_than_or_equal_to: 0 }
   #        end
-  #        
+  #
   #        def handle
   #          # By this time, if there were any errors the handler would have
   #          # already populated the errors object and returned.
@@ -81,23 +81,23 @@ module Lev
   #
   # These methods are available iff these data were supplied in the call
   # to the handler (not all handlers need all of this).  However, note that
-  # the Lev::HandleWith module supplies an easy way to call Handlers from 
+  # the Lev::HandleWith module supplies an easy way to call Handlers from
   # controllers -- when this way is used, all of the methods above are available.
   #
-  # Handler 'handle' methods don't return anything; they just set values in 
+  # Handler 'handle' methods don't return anything; they just set values in
   # the errors and results objects.  The documentation for each handler
   # should explain what the results will be and any nonstandard data required
   # to be passed in in the options.
   #
-  # In addition to the class- and instance-level "call" methods provided by 
+  # In addition to the class- and instance-level "call" methods provided by
   # Lev::Routine, Handlers have a class-level "handle" method (an alias of
   # the class-level "call" method).  The convention for handlers is that the
   # call methods take a hash of options/inputs.  The instance-level handle
   # method doesn't take any arguments since the arguments have been stored
   # as instance variables by the time the instance-level handle method is called.
-  # 
+  #
   # Example:
-  # 
+  #
   #   class MyHandler
   #     lev_handler
   #   protected
@@ -119,7 +119,7 @@ module Lev
     end
 
     module ClassMethods
-  
+
       def handle(options={})
         call(options)
       end
@@ -140,14 +140,14 @@ module Lev
           end
 
           # Attach a name to this dynamic class
-          const_set("#{group.to_s.capitalize}Paramifier", 
+          const_set("#{group.to_s.capitalize}Paramifier",
                     paramify_classes[group])
 
           paramify_classes[group].class_eval(&block)
           paramify_classes[group].group = group
         end
 
-        # Define the "#{group}_params" method to get the paramifier 
+        # Define the "#{group}_params" method to get the paramifier
         # instance wrapping the params.  Choose the subset of params
         # based on the group, choosing all params if the default group
         # is used.
@@ -155,7 +155,7 @@ module Lev
         define_method method_name.to_sym do
           if !instance_variable_get(variable_sym)
             params_subset = group == :paramify ? params : params[group]
-            instance_variable_set(variable_sym, 
+            instance_variable_set(variable_sym,
                                   self.class.paramify_classes[group].new(params_subset))
           end
           instance_variable_get(variable_sym)
@@ -187,12 +187,12 @@ module Lev
     attr_accessor :auth_error_details
 
     # This is a method required by Lev::Routine.  It enforces the steps common
-    # to all handlers.  
+    # to all handlers.
     def exec(options)
-      self.params = options.delete(:params)
-      self.request = options.delete(:request)
-      self.caller = options.delete(:caller)
-      self.options = options
+      self.params = options[:params]
+      self.request = options[:request]
+      self.caller = options[:caller]
+      self.options = options.except(:params, :request, :caller)
 
       setup
       raise Lev.configuration.security_transgression_error, auth_error_details unless authorized?
@@ -203,19 +203,19 @@ module Lev
     # Default setup implementation -- a no-op
     def setup; end
 
-    # Default authorized? implementation.  It returns true so that every 
+    # Default authorized? implementation.  It returns true so that every
     # handler realization has to make a conscious decision about who is authorized
-    # to call the handler. To help the common error of forgetting to override this 
+    # to call the handler. To help the common error of forgetting to override this
     # method in a handler instance, we provide an error message when this default
     # implementation is called.
     def authorized?
-      self.auth_error_details = 
+      self.auth_error_details =
         "Access to handlers is prevented by default.  You need to override the " +
         "'authorized?' in this handler to explicitly grant access."
       false
     end
 
-    
+
 
     # Helper method to validate paramified params and to transfer any errors
     # into the handler.

--- a/spec/background_job_spec.rb
+++ b/spec/background_job_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'lev/active_job'
 
 describe Lev::BackgroundJob do
 


### PR DESCRIPTION
The real changes are around line 192. Atom did the rest by itself...

I can backport this and make version 2.0.6 to fix Accounts after it's merged.