### PR TITLE
Removed the default output mapper

### DIFF
--- a/lib/lev/routine.rb
+++ b/lib/lev/routine.rb
@@ -377,8 +377,7 @@ module Lev
       input_mapper  = new_term_mapper(options[:translations][:inputs]) ||
                       new_term_mapper({ scope: symbol })
 
-      output_mapper = new_term_mapper(options[:translations][:outputs]) ||
-                      new_term_mapper({ scope: symbol })
+      output_mapper = new_term_mapper(options[:translations][:outputs])
 
       #
       # Set up the ignored errors in the routine instance
@@ -397,7 +396,7 @@ module Lev
 
       run_result.outputs.transfer_to(outputs) do |name|
         output_mapper.map(name)
-      end
+      end unless output_mapper.nil?
 
       options[:errors_are_fatal] = true if !options.has_key?(:errors_are_fatal)
       transfer_errors_from(run_result.errors, input_mapper, options[:errors_are_fatal])
@@ -458,8 +457,9 @@ module Lev
     end
 
     def result
-      @result ||= Result.new(Outputs.new,
-                             Errors.new(status, topmost_runner.class.raise_fatal_errors?))
+      @result ||= Result.new(
+        Outputs.new, Errors.new(status, topmost_runner.class.raise_fatal_errors?)
+      )
     end
 
     def reset_result!

--- a/lib/lev/version.rb
+++ b/lib/lev/version.rb
@@ -1,3 +1,3 @@
 module Lev
-  VERSION = '9.0.4'
+  VERSION = '10.0.0'
 end

--- a/spec/create_sprocket_spec.rb
+++ b/spec/create_sprocket_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe CreateSprocket do
-  
+RSpec.describe CreateSprocket do
+
   it "should transfer errors appropriately" do
     result = CreateSprocket.call(1,"42")
     errors = result.errors.collect { |error| error.translate }

--- a/spec/deep_merge_spec.rb
+++ b/spec/deep_merge_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Lev::Utilities do
+RSpec.describe Lev::Utilities do
 
   it "should merge properly" do
     default_options = {

--- a/spec/delegates_to_spec.rb
+++ b/spec/delegates_to_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DelegatingRoutine do
+RSpec.describe DelegatingRoutine do
 
   it "should delegate" do
     result = DelegatingRoutine.call(1,8)

--- a/spec/outputs_spec.rb
+++ b/spec/outputs_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Lev::Outputs do
+RSpec.describe Lev::Outputs do
 
   let(:outputs) { Lev::Outputs.new }
 
@@ -60,7 +60,7 @@ describe Lev::Outputs do
       :y
     end
 
-    other_outputs.add(:y, 6)    
+    other_outputs.add(:y, 6)
     expect(other_outputs.y).to eq [4,5,6]
   end
 
@@ -72,7 +72,7 @@ describe Lev::Outputs do
 
     outputs.transfer_to(other_outputs)
 
-    other_outputs.add(:y, 6)    
+    other_outputs.add(:y, 6)
     expect(other_outputs.x).to eq [4,5]
     expect(other_outputs.y).to eq 6
   end

--- a/spec/paramify_handler_spec.rb
+++ b/spec/paramify_handler_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ParamifyHandlerA do
+RSpec.describe ParamifyHandlerA do
   it 'should error out on badly formatted params' do
     result = ParamifyHandlerA.handle(params: {terms: {type: 'blah'}})
     errors = result.errors.collect { |error| error.translate }
@@ -8,7 +8,7 @@ describe ParamifyHandlerA do
   end
 end
 
-describe ParamifyHandlerB do
+RSpec.describe ParamifyHandlerB do
   it 'should error out on badly formatted ungrouped params' do
     result = ParamifyHandlerB.handle(params: {type: 'blah'})
     errors = result.errors.collect { |error| error.translate }

--- a/spec/routine_spec.rb
+++ b/spec/routine_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Lev::Routine do
+RSpec.describe Lev::Routine do
 
   before do
     stub_const 'RaiseRuntimeError', Class.new

--- a/spec/sprocket_handler_spec.rb
+++ b/spec/sprocket_handler_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SprocketHandler do
+RSpec.describe SprocketHandler do
   it 'should return fatal error messages' do
     allow_any_instance_of(SprocketHandler).to(
       receive(:params).and_return({

--- a/spec/sprocket_spec.rb
+++ b/spec/sprocket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper.rb'
 
-describe Sprocket do
+RSpec.describe Sprocket do
 
   it "should not be valid with bad inputs" do
     sprocket = Sprocket.new(integer_gt_2: 1, text_only_letters: 'abcd4')


### PR DESCRIPTION
I believe this will help us use less memory during the book import (the outputs get passed to the calling routine and so cannot be garbage-collected).

Will need to go through Tutor/Accounts and fix any places that assume the implicit outputs are available.