### PR TITLE
Add `copy!` & `details` to match ActiveModel:Errors version 5

### DIFF
--- a/lib/lev/better_active_model_errors.rb
+++ b/lib/lev/better_active_model_errors.rb
@@ -84,10 +84,10 @@ module Lev
     end
 
     # copy & details are needed to match `ActiveModel::Errors` interface
-    def self.copy!(other)
-      Lev::BetterActiveModelErrors.new(other)
+    def copy!(other)
+      initialize_dup(other)
     end
-    def self.details
+    def details
       {}
     end
 

--- a/lib/lev/better_active_model_errors.rb
+++ b/lib/lev/better_active_model_errors.rb
@@ -83,7 +83,7 @@ module Lev
       @messages = ActiveSupport::OrderedHash.new
     end
 
-    # match `ActiveModel::Errors.copy!` interface
+    # copy & details are needed to match `ActiveModel::Errors` interface
     def self.copy!(other)
       Lev::BetterActiveModelErrors.new(other)
     end

--- a/lib/lev/better_active_model_errors.rb
+++ b/lib/lev/better_active_model_errors.rb
@@ -83,6 +83,14 @@ module Lev
       @messages = ActiveSupport::OrderedHash.new
     end
 
+    # match `ActiveModel::Errors.copy!` interface
+    def self.copy!(other)
+      Lev::BetterActiveModelErrors.new(other)
+    end
+    def self.details
+      {}
+    end
+
     def initialize_dup(other)
       @types = other.types.dup
       @messages = other.messages.dup

--- a/lib/lev/version.rb
+++ b/lib/lev/version.rb
@@ -1,3 +1,3 @@
 module Lev
-  VERSION = "9.0.2"
+  VERSION = "9.0.3"
 end

--- a/spec/better_active_model_errors_spec.rb
+++ b/spec/better_active_model_errors_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'Better active model errors' do
-
+RSpec.describe 'BetterActiveModelErrors' do
   class DummyModel
     def self.human_attribute_name(attr, default='')
       return attr.capitalize
@@ -22,4 +21,16 @@ RSpec.describe 'Better active model errors' do
     expect(errors.include?('crash')).to be true
   end
 
+  it 'duplicates when copy called' do
+    model = OpenStruct.new
+
+    error = Lev::BetterActiveModelErrors.new(model)
+    error.set(:code, 'error')
+    expect(error.get(:code)).to eq 'error'
+
+    other = Lev::BetterActiveModelErrors.new(model)
+    other.set(:code, 'warning')
+    error.copy!(other)
+    expect(error.get(:code)).to eq 'warning'
+  end
 end


### PR DESCRIPTION
I attempted to figure out how to add spec for this but couldn't figure out how AR errors are  wrapped. There wasn't any existing specs to add on to that I could find.


Will remove need for hacks like this: 
https://github.com/openstax/accounts/blob/master/config/initializers/lev.rb#L9-L16