### PR TITLE
Allow Lev routines to specify the Lev ActiveJob class

### DIFF
--- a/lev.gemspec
+++ b/lev.gemspec
@@ -29,9 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "byebug"
   spec.add_development_dependency "jobba", ">= 1.5"
-
-  ## workaround for an issue using activerecord 4.2 outside of rails
-  spec.add_development_dependency "rails"
 end

--- a/lib/lev/active_job/configured_job.rb
+++ b/lib/lev/active_job/configured_job.rb
@@ -13,7 +13,7 @@ module Lev
       end
 
       def perform_later(*args, &block)
-        Lev::ActiveJob::Base.new.perform_later(routine_class, options, *args, &block)
+        routine_class.job_class.new.perform_later(routine_class, options, *args, &block)
       end
     end
   end

--- a/lib/lev/object.rb
+++ b/lib/lev/object.rb
@@ -8,6 +8,7 @@ class Object
       options[:transaction] ||= Lev::TransactionIsolation.mysql_default.symbol
       @transaction_isolation = Lev::TransactionIsolation.new(options[:transaction])
 
+      @job_class = options[:job_class]
       @active_job_enqueue_options = options[:active_job_enqueue_options]
 
       @raise_fatal_errors = options[:raise_fatal_errors]

--- a/lib/lev/version.rb
+++ b/lib/lev/version.rb
@@ -1,3 +1,3 @@
 module Lev
-  VERSION = '10.0.0'
+  VERSION = '10.1.0'
 end


### PR DESCRIPTION
Also changed duplicate uses_routine from an exception to a warning.