### PR TITLE
Support ruby 3

### DIFF
--- a/lib/lev/active_job/base.rb
+++ b/lib/lev/active_job/base.rb
@@ -3,7 +3,7 @@ module Lev
     class Base < Lev.configuration.job_class
       attr_accessor(:provider_job_id) unless respond_to?(:provider_job_id)
 
-      def perform_later(routine_class, options, *args, &block)
+      def perform_later(routine_class, options, *args, **kwargs, &block)
         # Create a new status object
         status = routine_class.create_status
 
@@ -25,7 +25,7 @@ module Lev
         # Queue up the job and set the provider_job_id
         # For delayed_job, requires either Rails 5 or
         # http://stackoverflow.com/questions/29855768/rails-4-2-get-delayed-job-id-from-active-job
-        provider_job_id = self.class.send(:job_or_instantiate, *args, &block)
+        provider_job_id = self.class.send(:job_or_instantiate, *args, **kwargs, &block)
                                     .enqueue(options)
                                     .provider_job_id
         status.set_provider_job_id(provider_job_id) \
@@ -35,14 +35,14 @@ module Lev
         status.id
       end
 
-      def perform(*args, &block)
+      def perform(*args, **kwargs, &block)
         # Pop arguments added by perform_later
         id = args.pop
         routine_class = Kernel.const_get(args.pop)
 
         routine_instance = routine_class.new(routine_class.find_status(id))
 
-        routine_instance.call(*args, &block)
+        routine_instance.call(*args, **kwargs, &block)
       end
     end
   end

--- a/lib/lev/active_job/configured_job.rb
+++ b/lib/lev/active_job/configured_job.rb
@@ -12,8 +12,8 @@ module Lev
         routine_class.active_job_enqueue_options.merge(@options)
       end
 
-      def perform_later(*args, &block)
-        routine_class.job_class.new.perform_later(routine_class, options, *args, &block)
+      def perform_later(*args, **kwargs, &block)
+        routine_class.job_class.new.perform_later(routine_class, options, *args, **kwargs, &block)
       end
     end
   end

--- a/lib/lev/null_status.rb
+++ b/lib/lev/null_status.rb
@@ -14,7 +14,7 @@ class Lev::NullStatus
     @kill_requested
   end
 
-  def method_missing(*args, &block)
+  def method_missing(*args, **kwargs, &block)
     nil
   end
 

--- a/lib/lev/version.rb
+++ b/lib/lev/version.rb
@@ -1,3 +1,3 @@
 module Lev
-  VERSION = '12.0.1'
+  VERSION = '12.1.0'
 end

--- a/lib/lev/version.rb
+++ b/lib/lev/version.rb
@@ -1,3 +1,3 @@
 module Lev
-  VERSION = '12.0.0'
+  VERSION = '12.0.1'
 end


### PR DESCRIPTION
[Context](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)