### PR TITLE
Use openstax_transaction_isolation

### DIFF
--- a/lev.gemspec
+++ b/lev.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activerecord', '>= 4.2'
   spec.add_runtime_dependency 'hashie'
   spec.add_runtime_dependency 'openstax_transaction_retry'
-  spec.add_runtime_dependency 'transaction_isolation'
+  spec.add_runtime_dependency 'openstax_transaction_isolation'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'jobba', '>= 2.0'

--- a/lib/lev/version.rb
+++ b/lib/lev/version.rb
@@ -1,3 +1,3 @@
 module Lev
-  VERSION = '12.1.0'
+  VERSION = '13.0.0'
 end


### PR DESCRIPTION
I needed to fork and update transaction_isolation for Ruby 3.1.